### PR TITLE
Add command helper methods that check SCPI errors

### DIFF
--- a/bendev/device.py
+++ b/bendev/device.py
@@ -173,8 +173,6 @@ class Device:
 
     def _update_info(self, dev_info: dict):
         """Update the device information."""
-        for k, v in dev_info.items():
-            setattr(self, k, v)
         self.usb_info = dev_info
 
     def _verify_open(self):
@@ -274,7 +272,9 @@ class Device:
         without sending a command, you can use the following command:
         >>> device.query(":SYST:ERR?")
         """
-        error_count = self.query(":SYST:ERR:COUNT?", timeout=timeout, read_interval=read_interval)
+        error_count = self.query(":SYST:ERR:COUNT?",
+                                 timeout=timeout,
+                                 read_interval=read_interval)
         if error_count != "0":
             error = self.query(":SYST:ERR?").split(",")
             raise SCPIError(int(error[0]), error[1])
@@ -301,10 +301,12 @@ class Device:
         except SCPIError as e:
             raise e
 
-    def cmd_query(self,
-                  command,
-                  timeout=0,
-                  read_interval=0.05) -> Union[str, int, float, list[Union[str, int, float]]]:
+    def cmd_query(
+        self,
+        command,
+        timeout=0,
+        read_interval=0.05
+    ) -> Union[str, int, float, list[Union[str, int, float]]]:
         """Sends a single command and tries to read a reply every read_interval 
         seconds until one arrives, or until timeout seconds have elapsed, 
         in which case a TimeoutError is raised. The SCPI error queue is

--- a/bendev/device.py
+++ b/bendev/device.py
@@ -4,10 +4,13 @@
 # @date 7 Jan 2022
 # @copyright Copyright © 2022 by Bentham Instruments Ltd.
 
+from __future__ import annotations
+
 import sys, time
 import hid  # from pip install hidapi
 import bendev.file_device as file_device
 import logging
+from typing import Union
 
 from bendev.exceptions import ExternalDeviceNotFound, DeviceClosed, SCPIError
 
@@ -17,7 +20,7 @@ _MAX_CHARACTERS = 64  # max size of USB HID packet
 logger = logging.getLogger("bendev")
 
 
-def scpi_convert(p: str) -> str | int | float:
+def scpi_convert(p: str) -> Union[str, int, float]:
     """Converts a string reply from a SCPI device to a string, int or float.
     If the string can be converted to an int, it is. If it can be converted 
     to a float, it is. Otherwise, the string is returned unaltered.
@@ -154,7 +157,7 @@ class Device:
                 logger.info(f"Connecting to device at {self.path}")                
                 self.device.open_path(self.path)
             else:
-                logger.info(f"Connecting to device with VID={dev["vendor_id"]}, PID={dev["product_id"]}" + " & SN={dev['serial_number']}" if self.serial_number else "")
+                logger.info(f'Connecting to device with VID={dev["vendor_id"]}, PID={dev["product_id"]}' + " & SN={dev['serial_number']}" if self.serial_number else "")
                 self.device.open(
                     dev["vendor_id"], dev["product_id"],
                     dev["serial_number"] if self.serial_number else None)
@@ -296,7 +299,7 @@ class Device:
     def cmd_query(self,
                   command,
                   timeout=0,
-                  read_interval=0.05) -> str | int | float | list[str | int | float]:
+                  read_interval=0.05) -> Union[str, int, float, list[Union[str, int, float]]]:
         """Sends a command and tries to read a reply every read_interval 
         seconds until one arrives, or until timeout seconds have elapsed, 
         in which case a TimeoutError is raised. The SCPI error queue is

--- a/bendev/device.py
+++ b/bendev/device.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 # @file device.py
 # @author Markus Führer
 # @date 7 Jan 2022
@@ -265,15 +266,13 @@ class Device:
         without sending a command, you can use the following command:
         >>> device.query(":SYST:ERR?")
         """
-        error_count = self.query(":SYST:ERR:COUNT?")
+        error_count = self.query(":SYST:ERR:COUNT?", timeout=timeout, read_interval=read_interval)
         if error_count != "0":
             error = self.query(":SYST:ERR?").split(",")
             raise SCPIError(int(error[0]), error[1])
 
     def cmd(self, command, timeout=0, read_interval=0.05):
-        """Sends a command and tries to read a reply every read_interval 
-        seconds  until one arrives, or until timeout seconds have elapsed, 
-        in which case a TimeoutError is raised. The SCPI error queue is
+        """Sends a (non-query) command to the device. The SCPI error queue is
         checked for errors and if any are found, a SCPIError is raised.
 
         Arguments:
@@ -299,7 +298,7 @@ class Device:
                   timeout=0,
                   read_interval=0.05) -> str | int | float | list[str | int | float]:
         """Sends a command and tries to read a reply every read_interval 
-        seconds  until one arrives, or until timeout seconds have elapsed, 
+        seconds until one arrives, or until timeout seconds have elapsed, 
         in which case a TimeoutError is raised. The SCPI error queue is
         checked for errors and if any are found, a RuntimeError is raised.
 

--- a/bendev/device.py
+++ b/bendev/device.py
@@ -1,18 +1,42 @@
 # @file device.py
 # @author Markus Führer
 # @date 7 Jan 2022
-# @copyright Copyright © 2022 by Bentham Instruments Ltd. 
+# @copyright Copyright © 2022 by Bentham Instruments Ltd.
 
 import sys, time
-import hid # from pip install hidapi
+import hid  # from pip install hidapi
 import bendev.file_device as file_device
 
-from bendev.exceptions import ExternalDeviceNotFound, DeviceClosed
+from bendev.exceptions import ExternalDeviceNotFound, DeviceClosed, SCPIError
 
 _ON_WINDOWS = (sys.platform == "win32")
-_MAX_CHARACTERS = 64 # max size of USB HID packet
+_MAX_CHARACTERS = 64  # max size of USB HID packet
 
-class Device: 
+
+def scpi_convert(p: str) -> str | int | float:
+    """Converts a string reply from a SCPI device to a string, int or float.
+    If the string can be converted to an int, it is. If it can be converted 
+    to a float, it is. Otherwise, the string is returned unaltered.
+
+    Arguments:
+        reply: string containing the reply from the SCPI device
+
+    Returns:
+        string, int or float
+    """
+    if p.startswith('"') and p.endswith('"'):
+        return p[1:-1]
+
+    try:
+        return int(p)
+    except ValueError:
+        try:
+            return float(p)
+        except ValueError:
+            return p
+
+
+class Device:
     """Simple High Level text-based SCPI over USB/HID communication interface 
     device class. Instantiation of this class connects to a device or raises
     an exception. Devices can be identified by serial number, product 
@@ -27,8 +51,15 @@ class Device:
     otherwise sent unaltered as USB HID packets.
     """
 
-    def __init__(self, serial_number=None, product_string=None, manufacturer_string="Bentham", encoding="ascii",
-        vendor_id=1240, product_id = None, hidraw=None):
+    def __init__(self,
+                 serial_number=None,
+                 product_string=None,
+                 manufacturer_string="Bentham",
+                 encoding="ascii",
+                 vendor_id=1240,
+                 product_id=None,
+                 hidraw=None,
+                 path=None):
         """Connects to the first device matching exact serial_number (if 
         present) or containing product_string (if present) or containing 
         manufacturer_string. Raises ExternalDeviceNotFound exception if no 
@@ -66,20 +97,25 @@ class Device:
         is solely identified by serial number.
         """
 
-        self.serial_number=serial_number
-        self.product_string=product_string
-        self.manufacturer_string=manufacturer_string
-        self.encoding=encoding
-        self.vendor_id=vendor_id
-        self.product_id=product_id
-        self.hidraw=hidraw
+        self.serial_number = serial_number
+        self.product_string = product_string
+        self.manufacturer_string = manufacturer_string
+        self.encoding = encoding
+        self.vendor_id = vendor_id
+        self.product_id = product_id
+        self.hidraw = hidraw
+        self.path = path
 
         self._connect()
 
     def _connect(self):
         """Connect using the parameters set at __init__ time."""
         self.device = None
-        if self.hidraw is None:
+        if self.path is not None:
+            self.device = hid.device()
+            self.device.open_path(self.path)
+            self.device.set_nonblocking(True)  # we'll handle waiting outselves
+        elif self.hidraw is None:
             found_devices = hid.enumerate()
             for dev in found_devices:
                 if self.serial_number:
@@ -89,7 +125,9 @@ class Device:
                     if self.product_string in dev["product_string"]:
                         break
                 elif self.vendor_id and self.product_id:
-                    if self.vendor_id == dev["vendor_id"] and self.product_id == dev["product_id"]:
+                    if self.vendor_id == dev[
+                            "vendor_id"] and self.product_id == dev[
+                                "product_id"]:
                         break
                 elif self.vendor_id:
                     if self.vendor_id == dev["vendor_id"]:
@@ -102,10 +140,14 @@ class Device:
                         "Missing qualifier; serial_number, product_string and manufacturer_string can't all be None."
                     )
             else:
-                raise ExternalDeviceNotFound(f"Can't find device ({self.serial_number or self.product_string})")
+                raise ExternalDeviceNotFound(
+                    f"Can't find device ({self.serial_number or self.product_string})"
+                )
             self.device = hid.device()
-            self.device.open(dev["vendor_id"], dev["product_id"], dev["serial_number"] if self.serial_number else None)
-            self.device.set_nonblocking(True) # we'll handle waiting outselves
+            self.device.open(
+                dev["vendor_id"], dev["product_id"],
+                dev["serial_number"] if self.serial_number else None)
+            self.device.set_nonblocking(True)  # we'll handle waiting outselves
         else:
             self.device = file_device.FileDevice(self.hidraw)
 
@@ -132,10 +174,12 @@ class Device:
         """
         self._verify_open()
         if (len(command) > _MAX_CHARACTERS):
-           raise IOError(f"Tried to send {len(command)} characters, max is {_MAX_CHARACTERS}")
-        if _ON_WINDOWS: 
-            command = "\x00"+command # hidapi calls on Windows require leading 0. 
-                    #(arg may be _MAX_CHARACTERS+1 chars in that case, that's ok)
+            raise IOError(
+                f"Tried to send {len(command)} characters, max is {_MAX_CHARACTERS}"
+            )
+        if _ON_WINDOWS:
+            command = "\x00" + command  # hidapi calls on Windows require leading 0.
+            #(arg may be _MAX_CHARACTERS+1 chars in that case, that's ok)
         self.device.write(command.encode(self.encoding))
 
     def read(self, timeout, read_interval):
@@ -157,7 +201,8 @@ class Device:
         while len(block := self.device.read(_MAX_CHARACTERS)) == 0:
             time.sleep(read_interval)
             if (timeout != 0) and time.time() - read_start_time > timeout:
-                raise TimeoutError(f"Device failed to respond in {timeout} seconds")
+                raise TimeoutError(
+                    f"Device failed to respond in {timeout} seconds")
         return bytes(block).decode(self.encoding).rstrip("\r\n\x00")
 
     def query(self, command, timeout=0, read_interval=0.05):
@@ -179,7 +224,78 @@ class Device:
         """
         self.write(command)
         return self.read(read_interval=read_interval, timeout=timeout)
-    
+
+    def check_scpi_error(self, timeout=0, read_interval=0.05):
+        """Checks the SCPI error queue for errors and raises a RuntimeError if
+        any are found. This function is called automatically after each 
+        command sent to the device. If you want to check the error queue 
+        without sending a command, you can use the following command:
+        >>> device.query(":SYST:ERR?")
+        """
+        error_count = self.query(":SYST:ERR:COUNT?")
+        if error_count != "0":
+            error = self.query(":SYST:ERR?").split(",")
+            raise SCPIError(int(error[0]), error[1])
+
+    def cmd(self, command, timeout=0, read_interval=0.05):
+        """Sends a command and tries to read a reply every read_interval 
+        seconds  until one arrives, or until timeout seconds have elapsed, 
+        in which case a TimeoutError is raised. The SCPI error queue is
+        checked for errors and if any are found, a SCPIError is raised.
+
+        Arguments:
+            command: string containing the command to send
+            timeout: number, time in seconds before raising a TimeoutError 
+                if no message is received. 0 or None means never time out. 
+                Default: 0
+            read_interval: number, time in seconds to sleep between attempts 
+                to read.
+                Default: 0.05
+        
+        Returns:
+            the device reply as a string
+        """
+        self.write(command)
+        try:
+            self.check_scpi_error(timeout=timeout, read_interval=read_interval)
+        except SCPIError as e:
+            raise e
+
+    def cmd_query(self,
+                  command,
+                  timeout=0,
+                  read_interval=0.05) -> list[str | int | float]:
+        """Sends a command and tries to read a reply every read_interval 
+        seconds  until one arrives, or until timeout seconds have elapsed, 
+        in which case a TimeoutError is raised. The SCPI error queue is
+        checked for errors and if any are found, a RuntimeError is raised.
+
+        Arguments:
+            command: string containing the command to send
+            timeout: number, time in seconds before raising a TimeoutError 
+                if no message is received. 0 or None means never time out. 
+                Default: 0
+            read_interval: number, time in seconds to sleep between attempts 
+                to read.
+                Default: 0.05
+        
+        Returns:
+            the device reply as a string
+        """
+        reply = self.query(command,
+                           timeout=timeout,
+                           read_interval=read_interval)
+        try:
+            self.check_scpi_error(timeout=timeout, read_interval=read_interval)
+        except SCPIError as e:
+            raise e
+
+        reply = reply.split(",")
+
+        reply = [scpi_convert(r) for r in reply]
+
+        return reply
+
     def __del__(self):
         self.close()
 
@@ -191,12 +307,16 @@ class Device:
 
     def __enter__(self):
         return self
-    
+
     def __exit__(self, type, value, traceback):
         self.close()
-        return False # do not catch exceptions
+        return False  # do not catch exceptions
 
-def list_connected_devices(manufacturer_string=None, product_string=None, vendor_ID=1240, verbose=False):
+
+def list_connected_devices(manufacturer_string=None,
+                           product_string=None,
+                           vendor_ID=1240,
+                           verbose=False):
     """list all the connected HID devices that match the manufacturer_string or
     product_string or vendor_ID. If a given string is found within the 
     appropriate device descriptor (even partially), the device is 
@@ -217,40 +337,41 @@ def list_connected_devices(manufacturer_string=None, product_string=None, vendor
         information
     """
     if verbose:
-        print ("Connected Devices:")
+        print("Connected Devices:")
     devices = hid.enumerate()
     filtered_devices = []
     for i, device in enumerate(sorted(devices, key=lambda d: d["path"])):
         if manufacturer_string is not None and\
-            manufacturer_string.upper() not in device['manufacturer_string'].upper(): 
+            manufacturer_string.upper() not in device['manufacturer_string'].upper():
             continue
         if product_string is not None and\
-            product_string.upper() not in device['product_string'].upper(): 
+            product_string.upper() not in device['product_string'].upper():
             continue
         if vendor_ID is not None and\
             vendor_ID != device['vendor_id']:
             continue
         if verbose:
-            print (f"Device {i+1}: ", end="")
-            print (f"{device['manufacturer_string']}, ", end="")
-            print (f"{device['product_string']}, ", end="")
-            print (f"sn={device['serial_number']}, ", end="")
-            print (f"v={device['vendor_id']}, ", end="")
-            print (f"p={device['product_id']}")
+            print(f"Device {i+1}: ", end="")
+            print(f"{device['manufacturer_string']}, ", end="")
+            print(f"{device['product_string']}, ", end="")
+            print(f"sn={device['serial_number']}, ", end="")
+            print(f"v={device['vendor_id']}, ", end="")
+            print(f"p={device['product_id']}")
         filtered_devices.append(device)
     return filtered_devices
+
 
 if __name__ == "__main__":
     devs = list_connected_devices(verbose=True)
     if len(devs) != 0:
-        with Device(serial_number = devs[0]["serial_number"]) as device:
-            print (device.query("*IDN?"))
+        with Device(serial_number=devs[0]["serial_number"]) as device:
+            print(device.query("*IDN?"))
 
         with Device(product_string=devs[0]["product_string"]) as device:
-            print (device.query("*IDN?"))
+            print(device.query("*IDN?"))
 
         d = Device()
-        print (d.query("*IDN?"))
+        print(d.query("*IDN?"))
         del d
     else:
-        print ("No devices found")
+        print("No devices found")

--- a/bendev/exceptions.py
+++ b/bendev/exceptions.py
@@ -1,9 +1,21 @@
 # @file exceptions.py
 # @author Markus Führer
 # @date 7 Jan 2022
-# @copyright Copyright © 2022 by Bentham Instruments Ltd. 
+# @copyright Copyright © 2022 by Bentham Instruments Ltd.
+
 
 class ExternalDeviceNotFound(IOError):
     """The target device was not found."""
+
+
 class DeviceClosed(IOError):
     """The connection to the target device is not open."""
+
+
+class SCPIError(RuntimeError):
+    """The target device has responded with an error in response to a command."""
+
+    def __init__(self, code: int, message: str):
+        super().__init__(f"SCPI error {code}: {message}")
+        self.code = code
+        self.scpi_message = message

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bendev
-version = 0.3.1
+version = 0.3.2
 url = https://github.com/BenthamInstruments/bendev
 description = Control module for Bentham Instruments Ltd SCPI devices
 long_description = file: README.md


### PR DESCRIPTION
- Adds cmd() and cmd_query() methods
- Allows opening using path (allowing 1-1 mapping if serial number not set)
- Can return all usb device info once open
- Adds logging
